### PR TITLE
Adding small numbers to feature counter

### DIFF
--- a/Ch4/03_Word2Vec_Example.ipynb
+++ b/Ch4/03_Word2Vec_Example.ipynb
@@ -210,7 +210,7 @@
     "    feats = []\n",
     "    for tokens in list_of_lists:\n",
     "        feat_for_this =  np.zeros(DIMENSION)\n",
-    "        count_for_this = 0\n",
+    "        count_for_this = 0 + 1e-5 # to avoid divide-by-zero \n",
     "        for token in tokens:\n",
     "            if token in w2v_model:\n",
     "                feat_for_this += w2v_model[token]\n",


### PR DESCRIPTION
to avoid divide-by-zero, we can add 1e-5 to 'count_for_this' variable. 
(or add such condition at the end of the nested for-loop)
if count_for_this == 0:
            count_for_this += 1e-5