### PR TITLE
Update 02_Bag_of_Words.ipynb

### DIFF
--- a/Ch3/02_Bag_of_Words.ipynb
+++ b/Ch3/02_Bag_of_Words.ipynb
@@ -131,7 +131,7 @@
    "source": [
     "#BoW with binary vectors\n",
     "count_vect = CountVectorizer(binary=True)\n",
-    "bow_rep_bin = count_vect.fit_transform(processed_docs)\n",
+    "count_vect.fit(processed_docs)\n",
     "temp = count_vect.transform([\"dog and dog are friends\"])\n",
     "print(\"Bow representation for 'dog and dog are friends':\", temp.toarray())"
    ]


### PR DESCRIPTION
probably clearer to drop `bow_rep_bin` because it isn't subsequently used. Also, use `fit` instead of `fit_transform`